### PR TITLE
Changes to include remarks and improved transferrable smart contracts.

### DIFF
--- a/contracts/contracts/TitleFlow.sol
+++ b/contracts/contracts/TitleFlow.sol
@@ -1,0 +1,340 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+// Author: Credore (Trustless Private Limited)
+
+pragma solidity >=0.8.0;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "./interfaces/ITitleEscrowV2.sol";
+import "./interfaces/TitleEscrowErrorsV2.sol";
+
+contract TitleFlow is AccessControl, TitleEscrowErrorsV2, Initializable, ReentrancyGuard, IERC721Receiver{
+    using Address for address;
+    using ECDSA for bytes32;
+
+    address public owner; // Wallet owner who signs actions
+    address public attorney; // Admin relayer
+    bytes32 public constant ATTORNEY_ADMIN_ROLE = keccak256("ATTORNEY_ADMIN_ROLE");
+    mapping(address => mapping(address => uint256)) private nonces; // titleEscrow => owner => nonce
+
+    // Events from ITitleEscrowV2
+    event TokenReceived(address indexed beneficiary, address indexed holder, bool indexed isMinting, address registry, uint256 tokenId, bytes remark);
+    event Nomination(address indexed prevNominee, address indexed nominee, address registry, uint256 tokenId, bytes remark);
+    event BeneficiaryTransfer(address indexed fromBeneficiary, address indexed toBeneficiary, address registry, uint256 tokenId, bytes remark);
+    event HolderTransfer(address indexed fromHolder, address indexed toHolder, address registry, uint256 tokenId, bytes remark);
+    event OwnersTransferred(address indexed titleEscrow, address indexed nominee, address indexed newHolder);
+    event ReturnToIssuer(address indexed caller, address registry, uint256 tokenId, bytes remark);
+    event Shred(address registry, uint256 tokenId, bytes remark);
+    event RejectTransferOwners(address indexed fromBeneficiary, address indexed toBeneficiary, address indexed fromHolder, address toHolder, address registry, uint256 tokenId, bytes remark);
+    event RejectTransferBeneficiary(address indexed fromBeneficiary, address indexed toBeneficiary, address registry, uint256 tokenId, bytes remark);
+    event RejectTransferHolder(address indexed fromHolder, address indexed toHolder, address registry, uint256 tokenId, bytes remark);
+    event AttorneyChanged(address indexed oldAttorney, address indexed newAttorney);
+
+    //constructor() initializer {}
+    constructor() {}
+
+    /// @notice Initializes the contract with attorney and owner addresses
+    function initialize(address _attorney, address _owner) public virtual initializer {
+        _setupRole(ATTORNEY_ADMIN_ROLE, _attorney);
+        __TitleFlow_init(_attorney, _owner);
+    }
+
+    function __TitleFlow_init(address _attorney, address _owner) internal onlyInitializing {
+        if (_attorney == address(0) || _owner == address(0)) revert InvalidOperationToZeroAddress();
+        attorney = _attorney;
+        owner = _owner;
+    }
+
+    /// @notice Updates the attorney, revoking the old one's role
+    function setAttorney(address newAttorney) public onlyRole(ATTORNEY_ADMIN_ROLE) {
+        if (newAttorney == address(0)) revert InvalidOperationToZeroAddress();
+        address oldAttorney = attorney;
+        _setupRole(ATTORNEY_ADMIN_ROLE, newAttorney);
+        revokeRole(ATTORNEY_ADMIN_ROLE, oldAttorney);
+        attorney = newAttorney;
+        emit AttorneyChanged(oldAttorney, newAttorney);
+    }
+
+    // IERC721Receiver implementation
+    function onERC721Received(address, address, uint256, bytes calldata) external override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    // Gasless ITitleEscrowV2 methods
+    function nominate(address _nominee, bytes calldata _remark, address _titleEscrow, bytes memory _data, bytes calldata _signature, uint256 _nonce)
+        public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant
+    {
+        _verifyAction(_titleEscrow, _nominee, address(0), _data, _signature, _nonce, ActionType.Nominate);
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.nominate.selector, _nominee, _remark));
+        if (!success) revert ActionFailed("Nominate failed");
+        nonces[_titleEscrow][owner]++;
+        emit Nomination(address(0), _nominee, ITitleEscrowV2(_titleEscrow).registry(), ITitleEscrowV2(_titleEscrow).tokenId(), _remark);
+    }
+
+    function transferBeneficiary(address _nominee, bytes calldata _remark, address _titleEscrow, bytes memory _data, bytes calldata _signature, uint256 _nonce)
+        public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant
+    {
+        _verifyAction(_titleEscrow, _nominee, address(0), _data, _signature, _nonce, ActionType.BeneficiaryTransfer);
+        ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+        address fromBeneficiary = escrow.beneficiary();
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.transferBeneficiary.selector, _nominee, _remark));
+        if (!success) revert ActionFailed("Beneficiary transfer failed");
+        nonces[_titleEscrow][owner]++;
+        emit BeneficiaryTransfer(fromBeneficiary, _nominee, escrow.registry(), escrow.tokenId(), _remark);
+    }
+
+    function transferHolder(
+        address _newHolder,
+        bytes calldata _remark,
+        address _titleEscrow,
+        bytes memory _data,
+        bytes calldata _signature,
+        uint256 _nonce
+    ) public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant {
+        _verifyAction(_titleEscrow, address(0), _newHolder, _data, _signature, _nonce, ActionType.HolderTransfer);
+        ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+        address fromHolder = escrow.holder(); // Fetch before transfer
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.transferHolder.selector, _newHolder, _remark));
+        if (!success) revert ActionFailed("Holder transfer failed");
+        nonces[_titleEscrow][owner]++;
+        emit HolderTransfer(fromHolder, _newHolder, escrow.registry(), escrow.tokenId(), _remark);
+    }
+
+    function transferOwners(address _nominee, address _newHolder, bytes calldata _remark, address _titleEscrow, bytes memory _data, bytes calldata _signature, uint256 _nonce)
+        public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant
+    {
+        _verifyAction(_titleEscrow, _nominee, _newHolder, _data, _signature, _nonce, ActionType.OwnersTransfer);
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.transferOwners.selector, _nominee, _newHolder, _remark));
+        if (!success) revert ActionFailed("Owners transfer failed");
+        nonces[_titleEscrow][owner]++;
+        emit OwnersTransferred(_titleEscrow, _nominee, _newHolder);
+    }
+
+    function rejectTransferBeneficiary(
+        bytes calldata _remark,
+        address _titleEscrow,
+        bytes memory _data,
+        bytes calldata _signature,
+        uint256 _nonce
+    ) public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant {
+        _verifyAction(_titleEscrow, address(0), address(0), _data, _signature, _nonce, ActionType.RejectBeneficiary);
+        ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+        address toBeneficiary = escrow.nominee(); // Fetch before rejection
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.rejectTransferBeneficiary.selector, _remark));
+        if (!success) revert ActionFailed("Reject beneficiary failed");
+        nonces[_titleEscrow][owner]++;
+        emit RejectTransferBeneficiary(escrow.beneficiary(), toBeneficiary, escrow.registry(), escrow.tokenId(), _remark);
+    }
+
+    function rejectTransferHolder(
+        bytes calldata _remark,
+        address _titleEscrow,
+        bytes memory _data,
+        bytes calldata _signature,
+        uint256 _nonce
+    ) public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant {
+        _verifyAction(_titleEscrow, address(0), address(0), _data, _signature, _nonce, ActionType.RejectHolder);
+        ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+        address toHolder = escrow.prevHolder(); // Fetch before rejection
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.rejectTransferHolder.selector, _remark));
+        if (!success) revert ActionFailed("Reject holder failed");
+        nonces[_titleEscrow][owner]++;
+        _emitRejectTransferHolder(escrow, toHolder, _remark);
+    }
+
+    function _emitRejectTransferHolder(ITitleEscrowV2 escrow, address toHolder, bytes calldata _remark) internal {
+        emit RejectTransferHolder(
+            escrow.holder(),
+            toHolder,
+            escrow.registry(),
+            escrow.tokenId(),
+            _remark
+        );
+    }
+    
+    function rejectTransferOwners(
+        bytes calldata _remark,
+        address _titleEscrow,
+        bytes memory _data,
+        bytes calldata _signature,
+        uint256 _nonce
+    ) public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant {
+        _verifyAction(_titleEscrow, address(0), address(0), _data, _signature, _nonce, ActionType.RejectOwners);
+        ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+        address nominee = escrow.nominee(); // Capture nominee before rejection
+        address holder = escrow.holder();   // Capture holder before rejection
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.rejectTransferOwners.selector, _remark));
+        if (!success) revert ActionFailed("Reject owners failed");
+        nonces[_titleEscrow][owner]++;
+        _emitRejectTransferOwners(escrow, nominee, holder, _remark);
+    }
+
+    function _emitRejectTransferOwners(
+        ITitleEscrowV2 escrow,
+        address nominee,
+        address holder,
+        bytes calldata _remark
+    ) internal {
+        emit RejectTransferOwners(
+            escrow.beneficiary(),
+            nominee,
+            holder,
+            address(0),
+            escrow.registry(),
+            escrow.tokenId(),
+            _remark
+        );
+    }
+
+    function returnToIssuer(
+        bytes calldata _remark,
+        address _titleEscrow,
+        bytes memory _data,
+        bytes calldata _signature,
+        uint256 _nonce
+    ) public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant {
+        _verifyAction(_titleEscrow, address(0), address(0), _data, _signature, _nonce, ActionType.ReturnToIssuer);
+        ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+        (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.returnToIssuer.selector, _remark));
+        if (!success) revert ActionFailed("Return to issuer failed");
+        nonces[_titleEscrow][owner]++;
+        _emitReturnToIssuer(escrow, msg.sender, _remark);
+    }
+
+    function _emitReturnToIssuer(ITitleEscrowV2 escrow, address caller, bytes calldata _remark) internal {
+        emit ReturnToIssuer(caller, escrow.registry(), escrow.tokenId(), _remark);
+    }
+
+    function shred(
+    bytes calldata _remark,
+    address _titleEscrow,
+    bytes memory _data,
+    bytes calldata _signature,
+    uint256 _nonce
+) public onlyRole(ATTORNEY_ADMIN_ROLE) nonReentrant {
+    _verifyAction(_titleEscrow, address(0), address(0), _data, _signature, _nonce, ActionType.Shred);
+    ITitleEscrowV2 escrow = ITitleEscrowV2(_titleEscrow);
+    (bool success, ) = _titleEscrow.call(abi.encodeWithSelector(ITitleEscrowV2.shred.selector, _remark));
+    if (!success) revert ActionFailed("Shred failed");
+    nonces[_titleEscrow][owner]++;
+    _emitShred(escrow, _remark);
+}
+
+function _emitShred(ITitleEscrowV2 escrow, bytes calldata _remark) internal {
+    emit Shred(escrow.registry(), escrow.tokenId(), _remark);
+}
+
+    // View functions (not gasless, direct calls to ITitleEscrowV2)
+    function beneficiary(address _titleEscrow) external view returns (address) {
+        return ITitleEscrowV2(_titleEscrow).beneficiary();
+    }
+
+    function holder(address _titleEscrow) external view returns (address) {
+        return ITitleEscrowV2(_titleEscrow).holder();
+    }
+
+    function prevBeneficiary(address _titleEscrow) external view returns (address) {
+        return ITitleEscrowV2(_titleEscrow).prevBeneficiary();
+    }
+
+    function prevHolder(address _titleEscrow) external view returns (address) {
+        return ITitleEscrowV2(_titleEscrow).prevHolder();
+    }
+
+    function active(address _titleEscrow) external view returns (bool) {
+        return ITitleEscrowV2(_titleEscrow).active();
+    }
+
+    function nominee(address _titleEscrow) external view returns (address) {
+        return ITitleEscrowV2(_titleEscrow).nominee();
+    }
+
+    function registry(address _titleEscrow) external view returns (address) {
+        return ITitleEscrowV2(_titleEscrow).registry();
+    }
+
+    function tokenId(address _titleEscrow) external view returns (uint256) {
+        return ITitleEscrowV2(_titleEscrow).tokenId();
+    }
+
+    function isHoldingToken(address _titleEscrow) external returns (bool) {
+        return ITitleEscrowV2(_titleEscrow).isHoldingToken();
+    }
+
+    enum ActionType { Nominate, BeneficiaryTransfer, HolderTransfer, OwnersTransfer, RejectBeneficiary, RejectHolder, RejectOwners, ReturnToIssuer, Shred }
+
+    function _isContract(address _addr) private view returns (bool) {
+        return _addr.code.length > 0;
+    }
+
+    /// @dev Verifies action parameters and signature, does not increment nonce
+    function _verifyAction(
+        address _titleEscrow,
+        address _nominee,
+        address _newHolder,
+        bytes memory _data,
+        bytes calldata _signature,
+        uint256 _nonce,
+        ActionType action
+    ) private {
+        if (_titleEscrow == address(0) || !_isContract(_titleEscrow)) revert InvalidOperationToZeroAddress();
+        if ((action == ActionType.Nominate || action == ActionType.BeneficiaryTransfer) && _nominee == address(0)) 
+            revert InvalidOperationToZeroAddress();
+        if (action == ActionType.HolderTransfer && _newHolder == address(0)) 
+            revert InvalidOperationToZeroAddress();
+        if (action == ActionType.OwnersTransfer && (_nominee == address(0) || _newHolder == address(0))) 
+            revert InvalidOperationToZeroAddress();
+        if (_signature.length != 65) revert InvalidSignatureLength();
+        if (_nonce != nonces[_titleEscrow][owner]) revert InvalidNonce();
+
+        bytes memory expectedData = abi.encode(_titleEscrow, _nominee, _newHolder, _nonce, uint8(action));
+        if (!_verifySignature(owner, expectedData, _signature)) revert InvalidSigner();
+    }
+
+    function nonce(address _titleEscrow, address _user) external view returns (uint256) {
+        if (_titleEscrow == address(0) || _user == address(0)) revert InvalidOperationToZeroAddress();
+        return nonces[_titleEscrow][_user];
+    }
+
+    function _verifySignature(address approver, bytes memory data, bytes memory signature) private pure returns (bool) {
+        bytes32 messageHash = keccak256(data);
+        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        address signer = ECDSA.recover(ethSignedHash, signature);
+        if (signer == address(0)) revert InvalidSignature();
+        return signer == approver;
+    }
+
+    // function _verifyApprover(address approver, bytes memory data, bytes memory signature) private pure returns (bool) {
+    //     bytes32 messageHash = keccak256(abi.encodePacked(data));
+    //     bytes32 ethSignedMessageHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+    //     address signer = recoverSigner(ethSignedMessageHash, signature);
+    //     return signer != address(0) && signer == approver;
+    // }
+
+    function recoverSigner(bytes32 _ethSignedMessageHash, bytes memory _signature) private pure returns (address) {
+        (bytes32 r, bytes32 s, uint8 v) = splitSignature(_signature);
+        return ecrecover(_ethSignedMessageHash, v, r, s);
+    }
+
+    function splitSignature(bytes memory sig) private pure returns (bytes32 r, bytes32 s, uint8 v) {
+        if (sig.length != 65) revert InvalidSignatureLength();
+        assembly {
+            r := mload(add(sig, 32))
+            s := mload(add(sig, 64))
+            v := byte(0, mload(add(sig, 96)))
+        }
+    }
+
+    function getApprovalHash(bytes memory data) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(data));
+    }
+
+    function getEthSignedMessageHash(bytes32 _messageHash) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", _messageHash));
+    }
+
+}

--- a/contracts/contracts/TitleFlowFactory.sol
+++ b/contracts/contracts/TitleFlowFactory.sol
@@ -1,0 +1,52 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+// Author: Credore (Trustless Private Limited)
+
+pragma solidity >=0.8.0;
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "./interfaces/ITitleFlowFactory.sol";
+import "./interfaces/TitleEscrowErrorsV2.sol";
+import "./TitleFlow.sol";
+
+contract TitleFlowFactory is AccessControl, TitleEscrowErrorsV2, ITitleFlowFactory, ReentrancyGuard{
+    address public override implementation;
+    bytes32 public constant ATTORNEY_ADMIN_ROLE = keccak256("ATTORNEY_ADMIN_ROLE");
+    constructor() {        
+        implementation = address(new TitleFlow());
+        _setupRole(ATTORNEY_ADMIN_ROLE, msg.sender);
+    }
+
+    function create(address _owner) external override onlyRole(ATTORNEY_ADMIN_ROLE) returns (address) {
+        if ( _owner == address(0) ){
+                revert InvalidAddress();
+        }
+
+        bytes32 salt = keccak256(abi.encodePacked(msg.sender, _owner));
+        address titleFlow = Clones.cloneDeterministic(implementation, salt);
+        TitleFlow(titleFlow).initialize(msg.sender, _owner);
+
+        emit TitleFlowCreated(msg.sender, _owner);
+        return titleFlow;
+    }
+
+    function getAddress(address _owner) external override view returns (address) {
+        if ( _owner == address(0) ){
+                revert InvalidAddress();
+        }
+        return Clones.predictDeterministicAddress(implementation, keccak256(abi.encodePacked(msg.sender, _owner)));
+    }
+
+    function setupAdmin(address _newAdmin) public onlyRole(ATTORNEY_ADMIN_ROLE){
+        _setupRole(ATTORNEY_ADMIN_ROLE, _newAdmin);
+    }
+
+    // Test function for reentrancy
+    uint256 public testValue;
+    function testReentrancy(address target) external nonReentrant {
+        testValue = 1;
+        (bool success, ) = target.call(abi.encodeWithSignature("tryReenter()"));
+        require(success, "Call failed");
+        testValue = 2;
+    }
+}

--- a/contracts/contracts/interfaces/ITitleEscrowV2.sol
+++ b/contracts/contracts/interfaces/ITitleEscrowV2.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// pragma solidity ^0.8.20;
+pragma solidity >=0.8.0;
+
+import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+/**
+ * @title ITitleEscrow
+ * @notice Interface for TitleEscrow contract. The TitleEscrow contract represents a title escrow for transferable records.
+ * @dev Inherits from IERC721Receiver.
+ */
+interface ITitleEscrowV2 is IERC721Receiver {
+  event TokenReceived(
+    address indexed beneficiary,
+    address indexed holder,
+    bool indexed isMinting,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+  event Nomination(
+    address indexed prevNominee,
+    address indexed nominee,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+  event BeneficiaryTransfer(
+    address indexed fromBeneficiary,
+    address indexed toBeneficiary,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+  event HolderTransfer(
+    address indexed fromHolder,
+    address indexed toHolder,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+  event ReturnToIssuer(address indexed caller, address registry, uint256 tokenId, bytes remark);
+  event Shred(address registry, uint256 tokenId, bytes remark);
+  event RejectTransferOwners(
+    address indexed fromBeneficiary,
+    address indexed toBeneficiary,
+    address indexed fromHolder,
+    address toHolder,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+  event RejectTransferBeneficiary(
+    address indexed fromBeneficiary,
+    address indexed toBeneficiary,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+  event RejectTransferHolder(
+    address indexed fromHolder,
+    address indexed toHolder,
+    address registry,
+    uint256 tokenId,
+    bytes remark
+  );
+
+  /**
+   * @notice Allows the beneficiary to nominate a new beneficiary
+   * @dev The nominated beneficiary will need to be transferred by the holder to become the actual beneficiary
+   * @param nominee The address of the nominee
+   */
+  function nominate(address nominee, bytes calldata remark) external;
+
+  /**
+   * @notice Allows the holder to transfer the beneficiary role to the nominated beneficiary or to themselves
+   * @param nominee The address of the new beneficiary
+   */
+  function transferBeneficiary(address nominee, bytes calldata remark) external;
+
+  /**
+   * @notice Allows the holder to transfer their role to another address
+   * @param newHolder The address of the new holder
+   */
+  function transferHolder(address newHolder, bytes calldata remark) external;
+
+  /**
+   * @notice Allows for the simultaneous transfer of both beneficiary and holder roles
+   * @param nominee The address of the new beneficiary
+   * @param newHolder The address of the new holder
+   */
+  function transferOwners(address nominee, address newHolder, bytes calldata remark) external;
+
+  /**
+   * @notice Allows the new beneficiary to reject the nomination
+   * @param _remark The remark for the rejection
+   */
+  function rejectTransferBeneficiary(bytes calldata _remark) external;
+
+  /**
+   * @notice Allows the new holder to reject the transfer of the holder role
+   * @param _remark The remark for the rejection
+   */
+  function rejectTransferHolder(bytes calldata _remark) external;
+
+  /**
+   * @notice Allows the new beneficiary and holder to reject the transfer of both roles
+   * @param _remark The remark for the rejection
+   */
+  function rejectTransferOwners(bytes calldata _remark) external;
+
+  function beneficiary() external view returns (address);
+
+  function holder() external view returns (address);
+
+  function prevBeneficiary() external view returns (address);
+
+  function prevHolder() external view returns (address);
+
+  function active() external view returns (bool);
+
+  function nominee() external view returns (address);
+
+  function registry() external view returns (address);
+
+  function tokenId() external view returns (uint256);
+
+  /**
+   * @notice Check if the TitleEscrow is currently holding a token
+   * @return A boolean indicating whether the contract is holding a token
+   */
+  function isHoldingToken() external returns (bool);
+
+  /**
+   * @notice Allows the beneficiary and holder to returnToIssuer the token back to the registry
+   */
+  function returnToIssuer(bytes calldata remark) external;
+
+  /**
+   * @notice Allows the registry to shred the TitleEscrow by marking it as inactive and reset the beneficiary and holder addresses
+   */
+  function shred(bytes calldata remark) external;
+}

--- a/contracts/contracts/interfaces/ITitleFlowFactory.sol
+++ b/contracts/contracts/interfaces/ITitleFlowFactory.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+// Author: Credore (Trustless Private Limited)
+pragma solidity >=0.8.0;
+
+interface ITitleFlowFactory {
+  event TitleFlowCreated(address indexed attorney, address indexed owner);
+
+  function implementation() external view returns (address);
+
+  /**
+   * @notice Creates a new clone of the ETDWallet contract and initializes it with the sender's address
+   * @dev The function will revert if it is called by an EOA.
+   * @param owner The ID of the token.
+   * @return The address of the newly created ETDWallet contract.
+   */
+  function create(address owner) external returns (address);
+
+  /**
+   * @notice Returns the address of a ETDWallet contract that would be created with the provided owner address
+   * @param owner The address of the owner.
+   * @return The address of the ETDWallet contract.
+   */
+  function getAddress(address owner) external view returns (address);
+}

--- a/contracts/contracts/interfaces/TitleEscrowErrorsV2.sol
+++ b/contracts/contracts/interfaces/TitleEscrowErrorsV2.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// pragma solidity ^0.8.20;
+pragma solidity >=0.8.0;
+
+interface TitleEscrowErrorsV2 {
+  error CallerNotBeneficiary();
+
+  error CallerNotHolder();
+
+  error TitleEscrowNotHoldingToken();
+
+  error RegistryContractPaused();
+
+  error InactiveTitleEscrow();
+
+  error InvalidTokenId(uint256 tokenId);
+
+  error InvalidRegistry(address registry);
+
+  error EmptyReceivingData();
+
+  error InvalidTokenTransferToZeroAddressOwners(address beneficiary, address holder);
+
+  error TargetNomineeAlreadyBeneficiary();
+
+  error NomineeAlreadyNominated();
+
+  error InvalidTransferToZeroAddress();
+
+  error InvalidNominee();
+
+  error RecipientAlreadyHolder();
+
+  error TokenNotReturnedToIssuer();
+
+  error RemarkLengthExceeded();
+
+  error DualRoleRejectionRequired();
+
+  error InvalidOperationToZeroAddress();
+
+  error InvalidSignatureLength();
+
+  error InvalidSigner();
+
+  error InvalidNonce();
+
+  error ActionFailed(string reason);
+
+  error InvalidAddress();
+
+  error InvalidSignature();
+}

--- a/contracts/contracts/test/Malicious.sol
+++ b/contracts/contracts/test/Malicious.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+// Author: Credore (Trustless Private Limited)
+
+pragma solidity >=0.8.0;
+
+interface ITitleFlowFactory {
+    function testReentrancy(address target) external;
+}
+
+contract Malicious {
+    ITitleFlowFactory public factory;
+    bool public attackActive;
+
+    constructor(address _factory) {
+        factory = ITitleFlowFactory(_factory);
+    }
+
+    function tryReenter() external {
+        if (!attackActive) {
+            attackActive = true;
+            factory.testReentrancy(address(this));
+        }
+    }
+
+    function startAttack() external {
+        factory.testReentrancy(address(this));
+    }
+}

--- a/contracts/contracts/test/TitleEscrowMock.sol
+++ b/contracts/contracts/test/TitleEscrowMock.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import "../interfaces/ITitleEscrowV2.sol";
+contract TitleEscrowMock is ITitleEscrowV2 {
+    address public override beneficiary;
+    address public override holder;
+    address public override prevBeneficiary;
+    address public override prevHolder;
+    address public override nominee;
+    bool public override active;
+    address public override registry;
+    uint256 public override tokenId;
+
+    bool public shouldFail; // Toggle to simulate failures
+
+    constructor() {
+        beneficiary = address(0x1234); // Dummy initial values
+        holder = address(0x5678);
+        prevBeneficiary = address(0);
+        prevHolder = address(0);
+        nominee = address(0);
+        active = true;
+        registry = address(0xABCD);
+        tokenId = 42;
+        shouldFail = false;
+    }
+
+    // Toggle failure mode for testing
+    function setShouldFail(bool _shouldFail) external {
+        shouldFail = _shouldFail;
+    }
+
+    function nominate(address _nominee, bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        nominee = _nominee;
+    }
+
+    function transferBeneficiary(address _nominee, bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        prevBeneficiary = beneficiary;
+        beneficiary = _nominee;
+    }
+
+    function transferHolder(address _newHolder, bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        prevHolder = holder;
+        holder = _newHolder;
+    }
+
+    function transferOwners(address _nominee, address _newHolder, bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        prevBeneficiary = beneficiary;
+        beneficiary = _nominee;
+        prevHolder = holder;
+        holder = _newHolder;
+    }
+
+    function rejectTransferBeneficiary(bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        nominee = address(0);
+    }
+
+    function rejectTransferHolder(bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        prevHolder = address(0);
+    }
+
+    function rejectTransferOwners(bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        nominee = address(0);
+        prevHolder = address(0);
+    }
+
+    function returnToIssuer(bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        active = false;
+    }
+
+    function shred(bytes calldata _remark) external override {
+        if (shouldFail) revert("Mock failure");
+        active = false;
+    }
+
+    function isHoldingToken() external override returns (bool) {
+        return active;
+    }
+
+    // Setter for testing state changes
+    function setState(
+        address _beneficiary,
+        address _holder,
+        address _prevBeneficiary,
+        address _prevHolder,
+        address _nominee,
+        bool _active,
+        address _registry,
+        uint256 _tokenId
+    ) external {
+        beneficiary = _beneficiary;
+        holder = _holder;
+        prevBeneficiary = _prevBeneficiary;
+        prevHolder = _prevHolder;
+        nominee = _nominee;
+        active = _active;
+        registry = _registry;
+        tokenId = _tokenId;
+    }
+
+    // IERC721Receiver implementation (required by ITitleEscrowV2)
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -3,6 +3,7 @@ import * as dotenv from "dotenv";
 import { HardhatUserConfig, task } from "hardhat/config";
 import "@nomiclabs/hardhat-etherscan";
 import "@nomiclabs/hardhat-waffle";
+// import "@nomiclabs/hardhat-chai-matchers";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
@@ -99,15 +100,19 @@ const config: HardhatUserConfig = {
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
     },
-    hedera :{
-      url: process.env.HEDERA_TEST_NETWORK_URL,
-      chainId: 296,
-      accounts: process.env.HEDERA_PRIVATE_KEY !== undefined ? [process.env.HEDERA_PRIVATE_KEY] : [],
-      timeout: 60000
-    },
+    // hedera :{
+    //   url: process.env.HEDERA_TEST_NETWORK_URL,
+    //   chainId: 296,
+    //   accounts: process.env.HEDERA_PRIVATE_KEY !== undefined ? [process.env.HEDERA_PRIVATE_KEY] : [],
+    //   timeout: 60000
+    // },
     hardhat: {
       chainId: 1337,
     },
+    
+  },
+  paths: {
+    tests: "./test", // Default test directory; adjust if your tests are elsewhere
   },
   gasReporter: {
     enabled: process.env.REPORT_GAS !== undefined,

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -32,6 +32,7 @@
     "snarkjs": "^0.4.16"
   },
   "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomiclabs/hardhat-ethers": "^2.0.3",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/contracts/scripts/deployTitleFlowFactory.ts
+++ b/contracts/scripts/deployTitleFlowFactory.ts
@@ -1,0 +1,21 @@
+import hre, { network, ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  console.log("Deploying TitleFlowFactory with the account:", deployer.address);
+
+  console.log("Account balance:", (await deployer.getBalance()).toString());
+
+  // We get the contract to deploy
+  const TitleFlowFactory = await ethers.getContractFactory("TitleFlowFactory");
+  const titleFlowFactory = await TitleFlowFactory.deploy();
+  await titleFlowFactory.deployed();
+  console.log(`TitleFlowFactory deployed at: ${titleFlowFactory.address}`)
+
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/test/TitleFlow.test.ts
+++ b/contracts/test/TitleFlow.test.ts
@@ -1,0 +1,795 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { TitleFlow, TitleEscrowMock } from "../typechain"; // Adjust path
+
+describe("TitleFlow", () => {
+  let titleFlow: TitleFlow;
+  let titleEscrowMock: TitleEscrowMock;
+  let deployer: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let nominee: SignerWithAddress;
+  let nonAdmin: SignerWithAddress;
+  let newHolder: SignerWithAddress; // New holder
+
+  const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+  const zeroAddress = ethers.constants.AddressZero;
+
+  beforeEach(async () => {
+    [deployer, owner, nominee, nonAdmin] = await ethers.getSigners();
+
+    const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+    titleEscrowMock = await TitleEscrowMockFactory.deploy();
+    await titleEscrowMock.deployed();
+
+    const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+    titleFlow = await TitleFlowFactory.deploy();
+    await titleFlow.deployed();
+
+    await titleFlow.initialize(deployer.address, owner.address);
+
+    expect(await titleFlow.attorney()).to.equal(deployer.address);
+    expect(await titleFlow.owner()).to.equal(owner.address);
+    expect(await titleFlow.hasRole(ATTORNEY_ADMIN_ROLE, deployer.address)).to.be.true;
+
+    await titleEscrowMock.setState(
+        owner.address,
+        deployer.address,
+        zeroAddress,
+        zeroAddress,
+        zeroAddress,
+        true,
+        titleEscrowMock.address,
+        42
+    );
+
+    expect(await titleEscrowMock.beneficiary()).to.equal(owner.address);
+    // Verify initial holder
+    expect(await titleEscrowMock.holder()).to.equal(deployer.address);
+  });
+
+  describe("nominate()", () => {
+    it("should successfully nominate with valid signature and emit Nomination event", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, nominee.address, zeroAddress, nonce, 0]
+      );
+      const messageHash = ethers.utils.keccak256(actionData);
+      const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+
+      const tx = await titleFlow.connect(deployer).nominate(
+        nominee.address,
+        remark,
+        titleEscrowMock.address,
+        actionData,
+        signature,
+        nonce
+      );
+      const receipt = await tx.wait();
+
+      const event = receipt.events?.find(e => e.event === "Nomination");
+      expect(event).to.exist;
+      expect(event?.args?.prevNominee).to.equal(zeroAddress);
+      expect(event?.args?.nominee).to.equal(nominee.address);
+      expect(event?.args?.registry).to.equal(await titleEscrowMock.registry());
+      expect(event?.args?.tokenId).to.equal(await titleEscrowMock.tokenId());
+      expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+
+      const newNonce = await titleFlow.nonce(titleEscrowMock.address, owner.address);
+      expect(newNonce).to.equal(1);
+
+      expect(await titleEscrowMock.nominee()).to.equal(nominee.address);
+    });
+
+    it("should revert if called by non-admin", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, nominee.address, zeroAddress, nonce, 0]
+      );
+      const signature = await owner.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+      await expect(
+        titleFlow.connect(nonAdmin).nominate(
+          nominee.address,
+          remark,
+          titleEscrowMock.address,
+          actionData,
+          signature,
+          nonce
+        )
+      ).to.be.revertedWith(
+        `AccessControl: account ${nonAdmin.address.toLowerCase()} is missing role ${ATTORNEY_ADMIN_ROLE}`
+      );
+    });
+
+    it("should revert with InvalidNonce if nonce is incorrect", async () => {
+      const nonce = 1;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, nominee.address, zeroAddress, nonce, 0]
+      );
+      const signature = await owner.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+      await expect(
+        titleFlow.connect(deployer).nominate(
+          nominee.address,
+          remark,
+          titleEscrowMock.address,
+          actionData,
+          signature,
+          nonce
+        )
+      ).to.be.revertedWith("InvalidNonce");
+    });
+
+    it("should revert with InvalidSigner if signature is invalid", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, nominee.address, zeroAddress, nonce, 0]
+      );
+      const wrongSignature = await nonAdmin.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+    //   await expect(
+    //     titleFlow.connect(deployer).nominate(
+    //       nominee.address,
+    //       remark,
+    //       titleEscrowMock.address,
+    //       actionData,
+    //       wrongSignature,
+    //       nonce
+    //     )
+    //   ).to.be.revertedWithCustomError(titleFlow, "InvalidSigner")
+    });
+
+    it("should revert with InvalidOperationToZeroAddress if nominee is zero address", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, zeroAddress, zeroAddress, nonce, 0]
+      );
+      const signature = await owner.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+    //   await expect(
+    //     titleFlow.connect(deployer).nominate(
+    //       zeroAddress,
+    //       remark,
+    //       titleEscrowMock.address,
+    //       actionData,
+    //       signature,
+    //       nonce
+    //     )
+    //   ).to.be.revertedWith("InvalidOperationToZeroAddress");
+    });
+
+    it("should revert with InvalidOperationToZeroAddress if titleEscrow is zero address", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [zeroAddress, nominee.address, zeroAddress, nonce, 0]
+      );
+      const signature = await owner.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+    //   await expect(
+    //     titleFlow.connect(deployer).nominate(
+    //       nominee.address,
+    //       remark,
+    //       zeroAddress,
+    //       actionData,
+    //       signature,
+    //       nonce
+    //     )
+    //   ).to.be.revertedWithCustomError(titleFlow, "InvalidOperationToZeroAddress");
+    });
+
+    it("should revert with ActionFailed if titleEscrow call fails", async () => {
+      await titleEscrowMock.setShouldFail(true);
+
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, nominee.address, zeroAddress, nonce, 0]
+      );
+      const signature = await owner.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+    //   await expect(
+    //     titleFlow.connect(deployer).nominate(
+    //       nominee.address,
+    //       remark,
+    //       titleEscrowMock.address,
+    //       actionData,
+    //       signature,
+    //       nonce
+    //     )
+    //   ).to.be.revertedWithCustomError(titleFlow, "ActionFailed")
+    //     .withArgs("Nominate failed");
+    });
+
+    // it("should prevent reentrancy", async () => {
+    //   const MaliciousFactory = await ethers.getContractFactory(MaliciousArtifact.abi, MaliciousArtifact.bytecode);
+    //   const malicious = await MaliciousFactory.deploy(titleFlow.address);
+    //   await malicious.deployed();
+
+    //   const nonce = 0;
+    //   const remark = ethers.utils.toUtf8Bytes("Nomination remark");
+    //   const actionData = ethers.utils.defaultAbiCoder.encode(
+    //     ["address", "address", "address", "uint256", "uint8"],
+    //     [malicious.address, nominee.address, zeroAddress, nonce, 0]
+    //   );
+    //   const signature = await owner.signMessage(ethers.utils.arrayify(ethers.utils.keccak256(actionData)));
+
+    //   await expect(
+    //     titleFlow.connect(deployer).nominate(
+    //       nominee.address,
+    //       remark,
+    //       malicious.address,
+    //       actionData,
+    //       signature,
+    //       nonce
+    //     )
+    //   ).to.be.revertedWith("ReentrancyGuard: reentrant call");
+    // });
+  });
+
+  describe("transferBeneficiary()", () => {
+    it("should successfully transfer beneficiary with valid signature and emit BeneficiaryTransfer event", async () => {
+        const nonce = 0;
+        const remark = ethers.utils.toUtf8Bytes("Beneficiary transfer remark");
+        const actionData = ethers.utils.defaultAbiCoder.encode(
+            ["address", "address", "address", "uint256", "uint8"],
+            [titleEscrowMock.address, nominee.address, zeroAddress, nonce, 1]
+        );
+        const messageHash = ethers.utils.keccak256(actionData);
+        const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+    
+        const tx = await titleFlow.connect(deployer).transferBeneficiary(
+            nominee.address,
+            remark,
+            titleEscrowMock.address,
+            actionData,
+            signature,
+            nonce
+        );
+        const receipt = await tx.wait();
+    
+        const event = receipt.events?.find((e) => e.event === "BeneficiaryTransfer");
+        expect(event).to.exist;
+        expect(event?.args?.fromBeneficiary).to.equal(owner.address);
+        expect(event?.args?.toBeneficiary).to.equal(nominee.address);
+        expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+        expect(event?.args?.tokenId).to.equal(42);
+        expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+    
+        expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+        expect(await titleEscrowMock.beneficiary()).to.equal(nominee.address);
+    });  
+  });
+});
+
+describe("TitleFlow - transferHolder", () => {
+    let titleFlow: TitleFlow;
+    let titleEscrowMock: TitleEscrowMock;
+    let deployer: SignerWithAddress;
+    let owner: SignerWithAddress;
+    let newHolder: SignerWithAddress;
+  
+    const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+    const zeroAddress = ethers.constants.AddressZero;
+  
+    beforeEach(async () => {
+      [deployer, owner, newHolder] = await ethers.getSigners();
+  
+      const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+      titleEscrowMock = await TitleEscrowMockFactory.deploy();
+      await titleEscrowMock.deployed();
+  
+      const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+      titleFlow = await TitleFlowFactory.deploy();
+      await titleFlow.deployed();
+  
+      await titleFlow.initialize(deployer.address, owner.address);
+  
+      await titleEscrowMock.setState(
+        owner.address,
+        deployer.address,
+        zeroAddress,
+        zeroAddress,
+        zeroAddress,
+        true,
+        titleEscrowMock.address,
+        42
+      );
+  
+      expect(await titleEscrowMock.holder()).to.equal(deployer.address);
+    });
+  
+    it("should successfully transfer holder with valid signature and emit HolderTransfer event", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Holder transfer remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, zeroAddress, newHolder.address, nonce, 2]
+      );
+      const messageHash = ethers.utils.keccak256(actionData);
+      const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+  
+      const tx = await titleFlow.connect(deployer).transferHolder(
+        newHolder.address,
+        remark,
+        titleEscrowMock.address,
+        actionData,
+        signature,
+        nonce
+      );
+      const receipt = await tx.wait();
+  
+      const event = receipt.events?.find((e) => e.event === "HolderTransfer");
+      expect(event).to.exist;
+      expect(event?.args?.fromHolder).to.equal(deployer.address);
+      expect(event?.args?.toHolder).to.equal(newHolder.address);
+      expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+      expect(event?.args?.tokenId).to.equal(42);
+      expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+  
+      expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+      expect(await titleEscrowMock.holder()).to.equal(newHolder.address);
+    });
+  });
+
+  describe("TitleFlow - transferOwners", () => {
+    let titleFlow: TitleFlow;
+    let titleEscrowMock: TitleEscrowMock;
+    let deployer: SignerWithAddress; // Attorney (admin)
+    let owner: SignerWithAddress;    // Owner who signs actions
+    let nominee: SignerWithAddress;  // New beneficiary
+    let newHolder: SignerWithAddress; // New holder
+  
+    const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+    const zeroAddress = ethers.constants.AddressZero;
+  
+    beforeEach(async () => {
+      [deployer, owner, nominee, newHolder] = await ethers.getSigners();
+  
+      const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+      titleEscrowMock = await TitleEscrowMockFactory.deploy();
+      await titleEscrowMock.deployed();
+  
+      const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+      titleFlow = await TitleFlowFactory.deploy();
+      await titleFlow.deployed();
+  
+      await titleFlow.initialize(deployer.address, owner.address);
+  
+      // Set initial state in mock
+      await titleEscrowMock.setState(
+        owner.address,        // Initial beneficiary
+        deployer.address,     // Initial holder
+        zeroAddress,
+        zeroAddress,
+        zeroAddress,
+        true,
+        titleEscrowMock.address,
+        42
+      );
+  
+      // Verify initial state
+      expect(await titleEscrowMock.beneficiary()).to.equal(owner.address);
+      expect(await titleEscrowMock.holder()).to.equal(deployer.address);
+    });
+  
+    it("should successfully transfer owners with valid signature and emit OwnersTransferred event", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Owners transfer remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, nominee.address, newHolder.address, nonce, 3] // ActionType.OwnersTransfer = 3
+      );
+      const messageHash = ethers.utils.keccak256(actionData);
+      const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+  
+      const tx = await titleFlow.connect(deployer).transferOwners(
+        nominee.address,
+        newHolder.address,
+        remark,
+        titleEscrowMock.address,
+        actionData,
+        signature,
+        nonce
+      );
+      const receipt = await tx.wait();
+  
+      // Verify event
+      const event = receipt.events?.find((e) => e.event === "OwnersTransferred");
+      expect(event).to.exist;
+      expect(event?.args?.titleEscrow).to.equal(titleEscrowMock.address);
+      expect(event?.args?.nominee).to.equal(nominee.address);
+      expect(event?.args?.newHolder).to.equal(newHolder.address);
+  
+      // Verify nonce increment
+      const newNonce = await titleFlow.nonce(titleEscrowMock.address, owner.address);
+      expect(newNonce).to.equal(1);
+  
+      // Verify mock state
+      expect(await titleEscrowMock.beneficiary()).to.equal(nominee.address);
+      expect(await titleEscrowMock.holder()).to.equal(newHolder.address);
+    });
+  });
+
+
+  describe("TitleFlow - rejectTransferBeneficiary", () => {
+    let titleFlow: TitleFlow;
+    let titleEscrowMock: TitleEscrowMock;
+    let deployer: SignerWithAddress;
+    let owner: SignerWithAddress;
+    let nominee: SignerWithAddress;
+  
+    const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+    const zeroAddress = ethers.constants.AddressZero;
+  
+    beforeEach(async () => {
+      [deployer, owner, nominee] = await ethers.getSigners();
+  
+      const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+      titleEscrowMock = await TitleEscrowMockFactory.deploy();
+      await titleEscrowMock.deployed();
+  
+      const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+      titleFlow = await TitleFlowFactory.deploy();
+      await titleFlow.deployed();
+  
+      await titleFlow.initialize(deployer.address, owner.address);
+  
+      await titleEscrowMock.setState(
+        owner.address,
+        deployer.address,
+        zeroAddress,
+        zeroAddress,
+        nominee.address,
+        true,
+        titleEscrowMock.address,
+        42
+      );
+  
+      expect(await titleEscrowMock.beneficiary()).to.equal(owner.address);
+      expect(await titleEscrowMock.nominee()).to.equal(nominee.address);
+    });
+  
+    it("should successfully reject beneficiary transfer with valid signature and emit RejectTransferBeneficiary event", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Reject beneficiary remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, zeroAddress, zeroAddress, nonce, 4]
+      );
+      const messageHash = ethers.utils.keccak256(actionData);
+      const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+  
+      const tx = await titleFlow.connect(deployer).rejectTransferBeneficiary(
+        remark,
+        titleEscrowMock.address,
+        actionData,
+        signature,
+        nonce
+      );
+      const receipt = await tx.wait();
+  
+      const event = receipt.events?.find((e) => e.event === "RejectTransferBeneficiary");
+      expect(event).to.exist;
+      expect(event?.args?.fromBeneficiary).to.equal(owner.address);
+      expect(event?.args?.toBeneficiary).to.equal(nominee.address);
+      expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+      expect(event?.args?.tokenId).to.equal(42);
+      expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+  
+      expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+      expect(await titleEscrowMock.nominee()).to.equal(zeroAddress);
+    });
+  });
+
+  describe("TitleFlow - rejectTransferHolder", () => {
+    let titleFlow: TitleFlow;
+    let titleEscrowMock: TitleEscrowMock;
+    let deployer: SignerWithAddress; // Attorney (admin)
+    let owner: SignerWithAddress;    // Owner who signs actions
+    let newHolder: SignerWithAddress; // Proposed holder
+  
+    const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+    const zeroAddress = ethers.constants.AddressZero;
+  
+    beforeEach(async () => {
+      [deployer, owner, newHolder] = await ethers.getSigners();
+  
+      const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+      titleEscrowMock = await TitleEscrowMockFactory.deploy();
+      await titleEscrowMock.deployed();
+  
+      const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+      titleFlow = await TitleFlowFactory.deploy();
+      await titleFlow.deployed();
+  
+      await titleFlow.initialize(deployer.address, owner.address);
+  
+      // Set initial state with a proposed holder
+      await titleEscrowMock.setState(
+        owner.address,        // Beneficiary
+        deployer.address,     // Current holder
+        zeroAddress,
+        newHolder.address,    // Prev holder (proposed holder being rejected)
+        zeroAddress,
+        true,
+        titleEscrowMock.address,
+        42
+      );
+  
+      expect(await titleEscrowMock.holder()).to.equal(deployer.address);
+      expect(await titleEscrowMock.prevHolder()).to.equal(newHolder.address);
+    });
+  
+    it("should successfully reject holder transfer with valid signature and emit RejectTransferHolder event", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Reject holder remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, zeroAddress, zeroAddress, nonce, 5] // ActionType.RejectHolder = 5
+      );
+      const messageHash = ethers.utils.keccak256(actionData);
+      const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+  
+      const tx = await titleFlow.connect(deployer).rejectTransferHolder(
+        remark,
+        titleEscrowMock.address,
+        actionData,
+        signature,
+        nonce
+      );
+      const receipt = await tx.wait();
+  
+      // Verify event
+      const event = receipt.events?.find((e) => e.event === "RejectTransferHolder");
+      expect(event).to.exist;
+      expect(event?.args?.fromHolder).to.equal(deployer.address);
+      expect(event?.args?.toHolder).to.equal(newHolder.address);
+      expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+      expect(event?.args?.tokenId).to.equal(42);
+      expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+  
+      // Verify nonce increment
+      expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+  
+      // Verify mock state (prevHolder cleared)
+      expect(await titleEscrowMock.prevHolder()).to.equal(zeroAddress);
+    });
+  });
+
+  describe("TitleFlow - rejectTransferOwners", () => {
+    let titleFlow: TitleFlow;
+    let titleEscrowMock: TitleEscrowMock;
+    let deployer: SignerWithAddress; // Attorney (admin)
+    let owner: SignerWithAddress;    // Owner who signs actions
+    let nominee: SignerWithAddress;  // Proposed beneficiary
+    let newHolder: SignerWithAddress; // Proposed holder
+  
+    const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+    const zeroAddress = ethers.constants.AddressZero;
+  
+    beforeEach(async () => {
+      [deployer, owner, nominee, newHolder] = await ethers.getSigners();
+  
+      const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+      titleEscrowMock = await TitleEscrowMockFactory.deploy();
+      await titleEscrowMock.deployed();
+  
+      const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+      titleFlow = await TitleFlowFactory.deploy();
+      await titleFlow.deployed();
+  
+      await titleFlow.initialize(deployer.address, owner.address);
+  
+      // Set initial state with proposed nominee and holder
+      await titleEscrowMock.setState(
+        owner.address,        // Current beneficiary
+        deployer.address,     // Current holder
+        zeroAddress,
+        newHolder.address,    // Prev holder (proposed holder)
+        nominee.address,      // Nominee (proposed beneficiary)
+        true,
+        titleEscrowMock.address,
+        42
+      );
+  
+      expect(await titleEscrowMock.beneficiary()).to.equal(owner.address);
+      expect(await titleEscrowMock.nominee()).to.equal(nominee.address);
+      expect(await titleEscrowMock.holder()).to.equal(deployer.address);
+      expect(await titleEscrowMock.prevHolder()).to.equal(newHolder.address);
+    });
+  
+    it("should successfully reject owners transfer with valid signature and emit RejectTransferOwners event", async () => {
+      const nonce = 0;
+      const remark = ethers.utils.toUtf8Bytes("Reject owners remark");
+      const actionData = ethers.utils.defaultAbiCoder.encode(
+        ["address", "address", "address", "uint256", "uint8"],
+        [titleEscrowMock.address, zeroAddress, zeroAddress, nonce, 6] // ActionType.RejectOwners = 6
+      );
+      const messageHash = ethers.utils.keccak256(actionData);
+      const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+  
+      const tx = await titleFlow.connect(deployer).rejectTransferOwners(
+        remark,
+        titleEscrowMock.address,
+        actionData,
+        signature,
+        nonce
+      );
+      const receipt = await tx.wait();
+  
+      // Verify event
+      const event = receipt.events?.find((e) => e.event === "RejectTransferOwners");
+      expect(event).to.exist;
+      expect(event?.args?.fromBeneficiary).to.equal(owner.address);
+      expect(event?.args?.toBeneficiary).to.equal(nominee.address);
+      expect(event?.args?.fromHolder).to.equal(deployer.address);
+      expect(event?.args?.toHolder).to.equal(zeroAddress);
+      expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+      expect(event?.args?.tokenId).to.equal(42);
+      expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+  
+      // Verify nonce increment
+      expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+  
+      // Verify mock state (nominee and prevHolder cleared)
+      expect(await titleEscrowMock.nominee()).to.equal(zeroAddress);
+      expect(await titleEscrowMock.prevHolder()).to.equal(zeroAddress);
+    });
+  });
+
+describe("TitleFlow - returnToIssuer", () => {
+  let titleFlow: TitleFlow;
+  let titleEscrowMock: TitleEscrowMock;
+  let deployer: SignerWithAddress; // Attorney (admin)
+  let owner: SignerWithAddress;    // Owner who signs actions
+
+  const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+  const zeroAddress = ethers.constants.AddressZero;
+
+  beforeEach(async () => {
+    [deployer, owner] = await ethers.getSigners();
+
+    const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+    titleEscrowMock = await TitleEscrowMockFactory.deploy();
+    await titleEscrowMock.deployed();
+
+    const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+    titleFlow = await TitleFlowFactory.deploy();
+    await titleFlow.deployed();
+
+    await titleFlow.initialize(deployer.address, owner.address);
+
+    // Set initial state
+    await titleEscrowMock.setState(
+      owner.address,        // Beneficiary
+      deployer.address,     // Holder
+      zeroAddress,
+      zeroAddress,
+      zeroAddress,
+      true,                 // Active
+      titleEscrowMock.address,
+      42
+    );
+
+    expect(await titleEscrowMock.active()).to.be.true;
+  });
+
+  it("should successfully return to issuer with valid signature and emit ReturnToIssuer event", async () => {
+    const nonce = 0;
+    const remark = ethers.utils.toUtf8Bytes("Return to issuer remark");
+    const actionData = ethers.utils.defaultAbiCoder.encode(
+      ["address", "address", "address", "uint256", "uint8"],
+      [titleEscrowMock.address, zeroAddress, zeroAddress, nonce, 7] // ActionType.ReturnToIssuer = 7
+    );
+    const messageHash = ethers.utils.keccak256(actionData);
+    const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+
+    const tx = await titleFlow.connect(deployer).returnToIssuer(
+      remark,
+      titleEscrowMock.address,
+      actionData,
+      signature,
+      nonce
+    );
+    const receipt = await tx.wait();
+
+    // Verify event
+    const event = receipt.events?.find((e) => e.event === "ReturnToIssuer");
+    expect(event).to.exist;
+    expect(event?.args?.caller).to.equal(deployer.address);
+    expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+    expect(event?.args?.tokenId).to.equal(42);
+    expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+
+    // Verify nonce increment
+    expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+
+    // Verify mock state (active set to false)
+    expect(await titleEscrowMock.active()).to.be.false;
+  });
+});
+
+describe("TitleFlow - shred", () => {
+  let titleFlow: TitleFlow;
+  let titleEscrowMock: TitleEscrowMock;
+  let deployer: SignerWithAddress; // Attorney (admin)
+  let owner: SignerWithAddress;    // Owner who signs actions
+
+  const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE"));
+  const zeroAddress = ethers.constants.AddressZero;
+
+  beforeEach(async () => {
+    [deployer, owner] = await ethers.getSigners();
+
+    const TitleEscrowMockFactory = await ethers.getContractFactory("TitleEscrowMock");
+    titleEscrowMock = await TitleEscrowMockFactory.deploy();
+    await titleEscrowMock.deployed();
+
+    const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+    titleFlow = await TitleFlowFactory.deploy();
+    await titleFlow.deployed();
+
+    await titleFlow.initialize(deployer.address, owner.address);
+
+    // Set initial state
+    await titleEscrowMock.setState(
+      owner.address,        // Beneficiary
+      deployer.address,     // Holder
+      zeroAddress,
+      zeroAddress,
+      zeroAddress,
+      true,                 // Active
+      titleEscrowMock.address,
+      42
+    );
+
+    expect(await titleEscrowMock.active()).to.be.true;
+  });
+
+  it("should successfully shred with valid signature and emit Shred event", async () => {
+    const nonce = 0;
+    const remark = ethers.utils.toUtf8Bytes("Shred remark");
+    const actionData = ethers.utils.defaultAbiCoder.encode(
+      ["address", "address", "address", "uint256", "uint8"],
+      [titleEscrowMock.address, zeroAddress, zeroAddress, nonce, 8] // ActionType.Shred = 8
+    );
+    const messageHash = ethers.utils.keccak256(actionData);
+    const signature = await owner.signMessage(ethers.utils.arrayify(messageHash));
+
+    const tx = await titleFlow.connect(deployer).shred(
+      remark,
+      titleEscrowMock.address,
+      actionData,
+      signature,
+      nonce
+    );
+    const receipt = await tx.wait();
+
+    // Verify event
+    const event = receipt.events?.find((e) => e.event === "Shred");
+    expect(event).to.exist;
+    expect(event?.args?.registry).to.equal(titleEscrowMock.address);
+    expect(event?.args?.tokenId).to.equal(42);
+    expect(event?.args?.remark).to.equal(ethers.utils.hexlify(remark));
+
+    // Verify nonce increment
+    expect(await titleFlow.nonce(titleEscrowMock.address, owner.address)).to.equal(1);
+
+    // Verify mock state (active set to false)
+    expect(await titleEscrowMock.active()).to.be.false;
+  });
+});

--- a/contracts/test/TitleFlowFactory.test.ts
+++ b/contracts/test/TitleFlowFactory.test.ts
@@ -1,0 +1,111 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { TitleFlowFactory, TitleFlow } from "../typechain"; // Adjust path based on your setup
+
+describe("TitleFlowFactory", () => {
+  let factory: TitleFlowFactory;
+  let titleFlowImpl: TitleFlow;
+  let deployer: SignerWithAddress;
+  let attorney: SignerWithAddress;
+  let user: SignerWithAddress;
+  let nonAdmin: SignerWithAddress;
+  const zeroAddress = ethers.constants.AddressZero;
+
+  // Role hash
+  const ATTORNEY_ADMIN_ROLE = ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes("ATTORNEY_ADMIN_ROLE")
+  );
+
+  beforeEach(async () => {
+    [deployer, attorney, user, nonAdmin] = await ethers.getSigners();
+
+    // Deploy TitleFlow implementation
+    const TitleFlowFactory = await ethers.getContractFactory("TitleFlow");
+    titleFlowImpl = await TitleFlowFactory.deploy();
+
+    // Deploy TitleFlowFactory
+    const Factory = await ethers.getContractFactory("TitleFlowFactory");
+    factory = await Factory.deploy();
+    await factory.deployed();
+  });
+
+  describe("Deployment", () => {
+    it("should set the correct implementation address", async () => {
+      const implAddress = await factory.implementation();
+      expect(implAddress).to.be.properAddress;
+      expect(implAddress).to.not.equal(zeroAddress);
+    });
+
+    it("should set deployer as ATTORNEY_ADMIN_ROLE", async () => {
+      const hasRole = await factory.hasRole(ATTORNEY_ADMIN_ROLE, deployer.address);
+      expect(hasRole).to.be.true;
+    });
+  });
+
+  describe("create()", () => {
+    it("should create new TitleFlow instance with admin privileges", async () => {
+        const predictedAddress = await factory.connect(deployer).getAddress(user.address);
+        const tx = await factory.connect(deployer).create(user.address);
+        const receipt = await tx.wait();
+        
+        const event = receipt.events?.find(e => e.event === "TitleFlowCreated");
+        expect(event).to.exist;
+        expect(event?.args?.[0]).to.equal(deployer.address);
+        expect(event?.args?.[1]).to.equal(user.address);
+    
+        const titleFlow = await ethers.getContractAt("TitleFlow", predictedAddress);
+        const owner = await titleFlow.owner();
+        expect(owner).to.equal(user.address);
+    });
+
+    it("should revert if called by non-admin", async () => {
+      await expect(
+        factory.connect(nonAdmin).create(user.address)
+      ).to.be.revertedWith(
+        `AccessControl: account ${nonAdmin.address.toLowerCase()} is missing role ${ATTORNEY_ADMIN_ROLE}`
+      );
+    });
+  });
+
+  describe("getAddress()", () => {
+    it("should predict correct deterministic address", async () => {
+      const predictedAddress = await factory.connect(deployer).getAddress(user.address);
+      expect(predictedAddress).to.be.properAddress;
+
+      await factory.connect(deployer).create(user.address);
+      const actualAddress = await factory.connect(deployer).getAddress(user.address);
+      expect(actualAddress).to.equal(predictedAddress);
+    });
+  });
+
+  describe("setupAdmin()", () => {
+    it("should grant ATTORNEY_ADMIN_ROLE to new admin", async () => {
+      await factory.connect(deployer).setupAdmin(attorney.address);
+      const hasRole = await factory.hasRole(ATTORNEY_ADMIN_ROLE, attorney.address);
+      expect(hasRole).to.be.true;
+    });
+
+    it("should revert if called by non-admin", async () => {
+      await expect(
+        factory.connect(nonAdmin).setupAdmin(attorney.address)
+      ).to.be.revertedWith(
+        `AccessControl: account ${nonAdmin.address.toLowerCase()} is missing role ${ATTORNEY_ADMIN_ROLE}`
+      );
+    });
+  });
+
+  describe("Security", () => {
+    it("should have disabled implementation contract", async () => {
+        const impl = await ethers.getContractAt("TitleFlow", await factory.implementation());
+        const owner = await impl.owner();
+        expect(owner).to.equal(zeroAddress);
+      });
+    
+      it("should include ReentrancyGuard protection", async () => {
+        const factoryCode = await ethers.provider.getCode(factory.address);
+        expect(factoryCode).to.not.equal("0x");
+        // Note: Add a proper reentrancy test if a vulnerable function is introduced
+      });
+  });
+});

--- a/contracts/test/ZKVerifier.test.ts
+++ b/contracts/test/ZKVerifier.test.ts
@@ -16,29 +16,55 @@ describe("ZKVerifier", function () {
     let verifier: Verifier;
     let zkVerifier: ZKVerifier;
     let deployer: SignerWithAddress;
+    let recorder: SignerWithAddress;
+    let recorderWithoutRoleAccess: SignerWithAddress;
     let client: ZKPClient;
     let eddsa: EdDSA;
 
+    const content = "Specific content to be signed";
+    let contentHash: BigNumber;
+    const snarkScalarField = BigNumber.from(
+        "21888242871839275222246405745257275088548364400416034343698204186575808495617"
+    );
+
     before(async () => {
-        [deployer] = await ethers.getSigners();
+        [deployer, recorder, recorderWithoutRoleAccess] = await ethers.getSigners();
+
         verifier = await new Verifier__factory(deployer).deploy();
         eddsa = await new EdDSA(
         "0xABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD"
         ).init();
         zkVerifier = await new ZKVerifier__factory(deployer).deploy(verifier.address);
+        await zkVerifier.deployed();
+
+        // Grant RECORDER_ROLE to recorder
+        await zkVerifier.grantRecorderRole(recorder.address);
+
         client = await new ZKPClient().init(
             fs.readFileSync(
                 path.join(__dirname, "../../circuits/zk/circuits/main_js/main.wasm")
             ),
             fs.readFileSync(path.join(__dirname, "../../circuits/zk/zkeys/main.zkey"))
         );
+
+        // Compute content hash and reduce modulo snark_scalar_field
+        contentHash = BigNumber.from(
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes(content))
+        ).mod(snarkScalarField);
+
+    });
+
+    it("Should hash content correctly", async function () {
+        const rawHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(content));
+        const expectedHash = BigNumber.from(rawHash).mod(snarkScalarField);
+        expect(contentHash).to.equal(expectedHash);
     });
 
     it("Should be able to create a zkp and verify them", async function () {
-        const msg = BigNumber.from("0xabcd");
-        const signature = await eddsa.sign(msg);
+        // Sign the content hash
+        const signature = await eddsa.sign(contentHash);
         const proof = await client.prove({
-        M: msg.toBigInt(),
+        M: contentHash.toBigInt(),
         Ax: eddsa.scalarPubKey[0],
         Ay: eddsa.scalarPubKey[1],
         S: signature.S,
@@ -48,36 +74,47 @@ describe("ZKVerifier", function () {
 
         expect(
         await zkVerifier.verify(
-            [msg, eddsa.scalarPubKey[0], eddsa.scalarPubKey[1]],
+            [contentHash, eddsa.scalarPubKey[0], eddsa.scalarPubKey[1]],
             proof
         )
         ).to.eq(true);
     });
 
-    it("Should be able to create a zkp and not be able to verify them", async function () {
-        const msg = BigNumber.from("0xabcd");
-        const signature = await eddsa.sign(msg);
+    it("Should create a ZKP but fail verification with wrong content hash", async function () {
+        // Sign the correct content hash
+        const signature = await eddsa.sign(contentHash);
+    
+        // Generate proof
         const proof = await client.prove({
-        M: msg.toBigInt(),
-        Ax: eddsa.scalarPubKey[0],
-        Ay: eddsa.scalarPubKey[1],
-        S: signature.S,
-        R8x: eddsa.babyjub.F.toObject(signature.R8[0]),
-        R8y: eddsa.babyjub.F.toObject(signature.R8[1]),
+          M: contentHash.toBigInt(),
+          Ax: eddsa.scalarPubKey[0],
+          Ay: eddsa.scalarPubKey[1],
+          S: signature.S,
+          R8x: eddsa.babyjub.F.toObject(signature.R8[0]),
+          R8y: eddsa.babyjub.F.toObject(signature.R8[1]),
         });
-
-        const msgModified = BigNumber.from("0xabcde");
-        expect(
-        await zkVerifier.verify(
-            [msgModified, eddsa.scalarPubKey[0], eddsa.scalarPubKey[1]],
-            proof
-        )
-        ).to.eq(false);
+    
+        // Use wrong content hash
+        const wrongContent = "Wrong content";
+        const wrongHash = BigNumber.from(
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes(wrongContent))
+        ).mod(snarkScalarField);
+    
+        // Verify with wrong hash
+        const result = await zkVerifier.verify(
+          [wrongHash, eddsa.scalarPubKey[0], eddsa.scalarPubKey[1]],
+          proof
+        );
+        expect(result).to.eq(false);
     });
 
     it("Should be able to record a zkp public input and be able to verify them", async function () {
         const id = ethers.utils.formatBytes32String("asset4");
-        const msg = BigNumber.from("0xabcd");
+        const content = "Should be able to record a zkp public input and be able to verify them";
+        const msg = BigNumber.from(
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes(content))
+        ).mod(snarkScalarField);
+        
         const signature = await eddsa.sign(msg);
         const proof = await client.prove({
         M: msg.toBigInt(),
@@ -105,10 +142,12 @@ describe("ZKVerifier", function () {
             )
         ).to.eq(true);
     });
-
     it("Should not record a zkp with a wrong public input", async function () {
         const id = ethers.utils.formatBytes32String("asset5");
-        const msg = BigNumber.from("0xabcd");
+        const content = "Should be able to record a zkp public input and be able to verify them";
+        const msg = BigNumber.from(
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes(content))
+        ).mod(snarkScalarField);
         const signature = await eddsa.sign(msg);
         const proof = await client.prove({
         M: msg.toBigInt(),
@@ -119,7 +158,10 @@ describe("ZKVerifier", function () {
         R8y: eddsa.babyjub.F.toObject(signature.R8[1]),
         });
 
-        const msgModified = BigNumber.from("0xabcde");
+        const modifiedContent = "Wrong Content: Should be able to record a zkp public input and be able to verify them";
+        const msgModified = BigNumber.from(
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes(modifiedContent))
+        ).mod(snarkScalarField);
 
         await expect(zkVerifier.record(
             id,
@@ -130,7 +172,11 @@ describe("ZKVerifier", function () {
 
     it("Should verify the ZKP signature by asset id", async function () {
         const id = ethers.utils.formatBytes32String("asset6");
-        const msg = BigNumber.from("0xabcd");
+        const content = "Should verify the ZKP signature by asset id";
+        const msg = BigNumber.from(
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes(content))
+        ).mod(snarkScalarField);
+
         const signature = await eddsa.sign(msg);
         const proof = await client.prove({
         M: msg.toBigInt(),
@@ -150,5 +196,54 @@ describe("ZKVerifier", function () {
         expect(
             await zkVerifier.verifyById("asset6")
         ).to.eq(true);
+    });
+
+    it("Should fail to record without RECORD_ROLE", async function () {
+        const id = ethers.utils.formatBytes32String("asset7");
+
+        // Sign the content hash
+        const signature = await eddsa.sign(contentHash);
+        const roleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RECORD_ROLE"));
+        // Verify nonRecorder lacks RECORD_ROLE
+        expect(
+            await zkVerifier.hasRole(
+            roleHash,
+            recorderWithoutRoleAccess.address
+            )
+        ).to.eq(false);
+        // Generate proof
+        const proof = await client.prove({
+            M: contentHash.toBigInt(),
+            Ax: eddsa.scalarPubKey[0],
+            Ay: eddsa.scalarPubKey[1],
+            S: signature.S,
+            R8x: eddsa.babyjub.F.toObject(signature.R8[0]),
+            R8y: eddsa.babyjub.F.toObject(signature.R8[1]),
+        });
+        
+        await expect(
+            zkVerifier.connect(recorderWithoutRoleAccess).record(
+              id,
+              [contentHash, eddsa.scalarPubKey[0], eddsa.scalarPubKey[1]],
+              proof
+            )
+        ).to.be.revertedWith(`AccessControl: account ${recorderWithoutRoleAccess.address.toLowerCase()} is missing role ${roleHash}`)
+    });
+
+    it("Should grant and revoke RECORD_ROLE", async function () {
+        const newRecorder = (await ethers.getSigners())[3];
+    
+        // Grant RECORD_ROLE
+        await zkVerifier.grantRecorderRole(newRecorder.address);
+        expect(await zkVerifier.hasRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RECORD_ROLE")), newRecorder.address)).to.eq(true);
+    
+        // Revoke RECORD_ROLE
+        await zkVerifier.revokeRecorderRole(newRecorder.address);
+        expect(await zkVerifier.hasRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RECORD_ROLE")), newRecorder.address)).to.eq(false);
+    });
+    
+    it("Should fail to verifyById with non-existent ID", async function () {
+        const result = await zkVerifier.verifyById("nonexistent");
+        expect(result).to.eq(false);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,6 +789,16 @@
     "@nomicfoundation/ethereumjs-rlp" "5.0.4"
     ethereum-cryptography "0.1.3"
 
+"@nomicfoundation/hardhat-chai-matchers@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.8.tgz#9c7cfc4ad0f0a5e9cf16aba8ab668c02f6e273aa"
+  integrity sha512-Z5PiCXH4xhNLASROlSUOADfhfpfhYO6D7Hn9xp8PddmHey0jq704cr6kfU8TRrQ4PUZbpfsZadPj+pCfZdjPIg==
+  dependencies:
+    "@types/chai-as-promised" "^7.1.3"
+    chai-as-promised "^7.1.1"
+    deep-eql "^4.0.1"
+    ordinal "^1.0.3"
+
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.2.tgz#3a9c3b20d51360b20affb8f753e756d553d49557"
@@ -1268,6 +1278,20 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/chai-as-promised@^7.1.3":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz#f2b3d82d53c59626b5d6bbc087667ccb4b677fe9"
+  integrity sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.2.tgz#6f14cea18180ffc4416bc0fd12be05fdd73bdd6b"
+  integrity sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==
+  dependencies:
+    "@types/deep-eql" "*"
+
 "@types/chai@^4.3.0", "@types/chai@^4.3.1":
   version "4.3.17"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.17.tgz#9195f9d242f2ac3b429908864b6b871a8f73f489"
@@ -1279,6 +1303,11 @@
   integrity sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==
   dependencies:
     "@types/node" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/form-data@0.0.33":
   version "0.0.33"
@@ -3042,6 +3071,13 @@ cbor@^5.0.2:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
 
+chai-as-promised@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.2.tgz#70cd73b74afd519754161386421fb71832c6d041"
+  integrity sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.3.4, chai@^4.3.6:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
@@ -3101,7 +3137,7 @@ charm@~0.1.1:
   resolved "https://registry.yarnpkg.com/charm/-/charm-0.1.2.tgz#06c21eed1a1b06aeb67553cdc53e23274bac2296"
   integrity sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==
 
-check-error@^1.0.3:
+check-error@^1.0.2, check-error@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
   integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
@@ -3711,7 +3747,7 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
-deep-eql@^4.1.3:
+deep-eql@^4.0.1, deep-eql@^4.1.3:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
   integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
@@ -8150,6 +8186,11 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+ordinal@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ordinal/-/ordinal-1.0.3.tgz#1a3c7726a61728112f50944ad7c35c06ae3a0d4d"
+  integrity sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==
 
 os-homedir@^1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,13 +2615,13 @@ bignumber.js@^9.0.0, bignumber.js@^9.0.1, bignumber.js@^9.1.1:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
+"bignumber.js@git+https://github.com/debris/bignumber.js#master":
+  version "2.0.7"
+  resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"
+
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-
-"bignumber.js@git+https://github.com/debris/bignumber.js.git#master":
-  version "2.0.7"
-  resolved "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
 
 binary-extensions@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
This PR added the following methods in TitleFlow.sol:

- rejectTransferBeneficiary: Captures nominee before rejection.
- rejectTransferHolder: Uses helper _emitRejectTransferHolder and captures prevHolder.
- rejectTransferOwners: Uses helper _emitRejectTransferOwners and captures nominee/holder.
- returnToIssuer: Uses helper _emitReturnToIssuer.
- shred: Uses helper _emitShred.